### PR TITLE
Only load on product pages.

### DIFF
--- a/storefront-sticky-add-to-cart.php
+++ b/storefront-sticky-add-to-cart.php
@@ -26,6 +26,10 @@ if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
  * @since  1.0.0
  * @return object Storefront_Sticky_Add_to_Cart
  */
+ 
+
+if ( ! is_product() ) {
+	
 function Storefront_Sticky_Add_to_Cart() {
 	return Storefront_Sticky_Add_to_Cart::instance();
 } // End Storefront_Sticky_Add_to_Cart()
@@ -300,3 +304,4 @@ final class Storefront_Sticky_Add_to_Cart {
 	}
 
 } // End Class
+}


### PR DESCRIPTION
No one needs the js & css loading on home, blog, article, page, product archive, cat archive, .........all the time.  
### Let's only load it when we need it.

This--->  if ( ! is_product() ) { <----goes somewhere
